### PR TITLE
use configured configuration directory in ovpn_run

### DIFF
--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -18,7 +18,7 @@ if [ ! -c /dev/net/tun ]; then
 fi
 
 if [ ! -d "$OPENVPN/ccd" ]; then
-    mkdir -p $OPENVPN/ccd
+    mkdir -p "$OPENVPN/ccd"
 fi
 
 # Setup NAT forwarding if requested

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -18,7 +18,7 @@ if [ ! -c /dev/net/tun ]; then
 fi
 
 if [ ! -d "$OPENVPN/ccd" ]; then
-    mkdir -p /etc/openvpn/ccd
+    mkdir -p $OPENVPN/ccd
 fi
 
 # Setup NAT forwarding if requested


### PR DESCRIPTION
Create the checked dir unless it exists.
Not create a dir in a possible different location.